### PR TITLE
Changes to `_random` opcodes and to `hikey`

### DIFF
--- a/_data/sfz/syntax.yml
+++ b/_data/sfz/syntax.yml
@@ -406,11 +406,11 @@ categories:
     short_description:
       "Its a 'hint' to the ARIA engine, others implementations don't have to follow."
     version: "ARIA"
-    
+
   - name: "*_mod"
     short_description:
       "Determines whether a parameter is modulated by addition or multiplication."
-    version: "ARIA"    
+    version: "ARIA"
 
   - name: "set_hdccN"
     short_description:
@@ -679,7 +679,7 @@ categories:
       value:
         type_name: "integer"
         default: 127
-        min: 0
+        min: -1
         max: 127
 
     - name: "lovel"
@@ -1831,7 +1831,7 @@ categories:
             min: -96
             max: 24
             unit: "dB"
-           
+
     - name: "eqN_dynamic"
       short_description: "Specifies when EQ is recalculated."
       version: "ARIA"
@@ -1839,7 +1839,7 @@ categories:
         type_name: "integer"
         default: 0
         min: 0
-        max: 1                
+        max: 1
 
   - name: "Filter"
     opcodes:
@@ -2771,7 +2771,7 @@ categories:
         default: 1
         min: 0
         max: 1
-        
+
     - name: "ampeg_dynamic"
       short_description: "Specifies when envelope durations are recalculated."
       version: "ARIA"
@@ -2835,7 +2835,7 @@ categories:
         default: 1
         min: 0
         max: 1
-        
+
     - name: "fileg_dynamic"
       short_description: "Specifies when envelope durations are recalculated."
       version: "ARIA"
@@ -2883,7 +2883,7 @@ categories:
         default: 1
         min: 0
         max: 1
-        
+
     - name: "pitcheg_dynamic"
       short_description: "Specifies when envelope durations are recalculated."
       version: "ARIA"
@@ -2891,7 +2891,7 @@ categories:
         type_name: "integer"
         default: 0
         min: 0
-        max: 1        
+        max: 1
 
     - name: "fileg_attack"
       short_description: "EG attack time."
@@ -3589,7 +3589,7 @@ categories:
         midi_cc:
         - name: "egN_driveshape_onccX"
           short_description: ""
-          version: "Cakewalk SFZ v2"      
+          version: "Cakewalk SFZ v2"
 
   - name: "LFO"
     url: "/types/lfo"

--- a/opcodes/amp_random.md
+++ b/opcodes/amp_random.md
@@ -3,6 +3,9 @@ layout: "sfz/opcode"
 lang: "en"
 opcode_name: "amp_random"
 ---
+Like all SFZ `ZZZ_random` opcodes, it is computed when the region is triggered and does
+not change until it stops playing.
+
 ## Examples
 
 ```

--- a/opcodes/delay_random.md
+++ b/opcodes/delay_random.md
@@ -3,8 +3,10 @@ layout: "sfz/opcode"
 lang: "en"
 opcode_name: "delay_random"
 ---
-If the region receives a note-off message before delay time,
-the region won't play. Similar to [delay](delay) otherwise.
+If the region receives a note-off message before delay time, the region won't
+play. Similar to [delay](delay) otherwise. Like all SFZ `ZZZ_random` opcodes, it is
+computed when the region is triggered and does not change until it stops
+playing.
 
 ## Examples
 

--- a/opcodes/lokey.md
+++ b/opcodes/lokey.md
@@ -26,3 +26,9 @@ When an instrument is sampled every minor third, this kind of usage will be comm
 <region> sample=c5.wav  lokey=71 hikey=73 pitch_keycenter=72
 <region> sample=eb5.wav lokey=74 hikey=76 pitch_keycenter=75
 ```
+
+## Disabling the note-on trigger
+
+If you want to have the region trigger on MIDI continuous controllers (CC), you
+have to disable the note range matching entirely by using -1 as the `hikey`
+value.

--- a/opcodes/offset_random.md
+++ b/opcodes/offset_random.md
@@ -7,12 +7,16 @@ In many cases, will need to be used with a small [ampeg_attack](ampeg_attack)
 value to avoid clicks caused by the region playing starting with a point
 in the sample file where the value is non-zero.
 
-Also, when using a player with disk streaming, such as Sforzando/ARIA, which does
-not load entire samples to memory but instead preloads on only the start (usually
-about half a second, following the original Gigasampler method), it is generally
-not a good idea to make the offset_random values so high that they would cause the
-offset to exceeed this buffer. In practice, that means keeping offset_random no
-higher than 20000 or so on most systems.
+Also, when using a player with disk streaming, such as Sforzando/ARIA, which
+does not load entire samples to memory but instead preloads on only the start
+(usually about half a second, following the original Gigasampler method), it is
+generally not a good idea to make the offset_random values so high that they
+would cause the offset to exceeed this buffer. ARIA will try to accomodate
+potential delays by preloading more data but in practice, that means keeping
+offset_random no higher than 20000 or so on most systems.
+
+Like all SFZ `ZZZ_random` opcodes, it is computed when the region is triggered
+and does not change until it stops playing.
 
 ## Examples
 

--- a/opcodes/pitch_random.md
+++ b/opcodes/pitch_random.md
@@ -3,6 +3,9 @@ layout: "sfz/opcode"
 lang: "en"
 opcode_name: "pitch_random"
 ---
+Like all SFZ `ZZZ_random` opcodes, it is computed when the region is triggered and does
+not change until it stops playing.
+
 ## Examples
 
 ```


### PR DESCRIPTION
Just some clarifications, mainly useful for people developing sfz players for the `random` opcodes.