### PR TITLE
Added info on the control header and default_path

### DIFF
--- a/_data/sfz/syntax.yml
+++ b/_data/sfz/syntax.yml
@@ -359,7 +359,7 @@ categories:
       type_name: "string"
 
   - name: "default_path"
-    short_description: "Relative path for samples."
+    short_description: "Prefix to add to the sample path."
     version: "SFZ v2"
     value:
       type_name: "string"
@@ -406,11 +406,11 @@ categories:
     short_description:
       "Its a 'hint' to the ARIA engine, others implementations don't have to follow."
     version: "ARIA"
-    
+
   - name: "*_mod"
     short_description:
       "Determines whether a parameter is modulated by addition or multiplication."
-    version: "ARIA"    
+    version: "ARIA"
 
   - name: "set_hdccN"
     short_description:
@@ -1831,7 +1831,7 @@ categories:
             min: -96
             max: 24
             unit: "dB"
-           
+
     - name: "eqN_dynamic"
       short_description: "Specifies when EQ is recalculated."
       version: "ARIA"
@@ -1839,7 +1839,7 @@ categories:
         type_name: "integer"
         default: 0
         min: 0
-        max: 1                
+        max: 1
 
   - name: "Filter"
     opcodes:
@@ -2771,7 +2771,7 @@ categories:
         default: 1
         min: 0
         max: 1
-        
+
     - name: "ampeg_dynamic"
       short_description: "Specifies when envelope durations are recalculated."
       version: "ARIA"
@@ -2835,7 +2835,7 @@ categories:
         default: 1
         min: 0
         max: 1
-        
+
     - name: "fileg_dynamic"
       short_description: "Specifies when envelope durations are recalculated."
       version: "ARIA"
@@ -2883,7 +2883,7 @@ categories:
         default: 1
         min: 0
         max: 1
-        
+
     - name: "pitcheg_dynamic"
       short_description: "Specifies when envelope durations are recalculated."
       version: "ARIA"
@@ -2891,7 +2891,7 @@ categories:
         type_name: "integer"
         default: 0
         min: 0
-        max: 1        
+        max: 1
 
     - name: "fileg_attack"
       short_description: "EG attack time."
@@ -3589,7 +3589,7 @@ categories:
         midi_cc:
         - name: "egN_driveshape_onccX"
           short_description: ""
-          version: "Cakewalk SFZ v2"      
+          version: "Cakewalk SFZ v2"
 
   - name: "LFO"
     url: "/types/lfo"

--- a/headers/control.md
+++ b/headers/control.md
@@ -2,9 +2,8 @@
 title: ‹control›
 lang: en
 ---
-SFZ 2 header which should come before ‹[global](global)› in the file,
-and can contain the following special directives,
-which should not be used under other headers:
+SFZ 2 header can contain the following special directives, which should not
+be used under other headers:
 
 - [#define](/opcodes/define)
 - [default_path](/opcodes/default_path)
@@ -13,8 +12,12 @@ which should not be used under other headers:
 - [label_ccN](/opcodes/label_ccN)
 - [set_ccN](/opcodes/set_ccN)
 
-Multiple <control> headers can be used in one file, and this can be very
-useful when specifying default_path. This path will then be used for
-all regions until another <control> header is encountered.
+Multiple <control> headers can be used in one file, in which case the older
+<control> opcodes are replaced by the new <control> opcodes. In ARIA, if you do
+not specify a new value for an opcode the old value will be kept, except for the
+[default_path](/opcodes/default_path) which will be reset to an empty value on a
+new <control> header. This can be very useful when specifying
+[default_path](/opcodes/default_path). This path will then be used for all
+regions until another <control> header is encountered.
 
 See also [ARIA Extensions](/extensions/aria/#instrument-settings).

--- a/opcodes/default_path.md
+++ b/opcodes/default_path.md
@@ -3,10 +3,17 @@ layout: "sfz/opcode"
 lang: "en"
 opcode_name: "default_path"
 ---
-Used under the ‹[control](/headers/control)› header.
+Used under the ‹[control](/headers/control)› header. Changes the root path for
+samples.
 
 ## Example
 
 ```
-default_path=../Samples
+default_path=../Samples/
 ```
+
+The string will be added as a prefix to every sample path defined until the end
+of the file or until another <control> header is encountered. As such, it should
+end with a forward or backward slash if it specifies a subdirectory, but you can
+also use it without a forward or backward slash if your samples share a common
+prefix for example.

--- a/opcodes/default_path.md
+++ b/opcodes/default_path.md
@@ -3,8 +3,7 @@ layout: "sfz/opcode"
 lang: "en"
 opcode_name: "default_path"
 ---
-Used under the ‹[control](/headers/control)› header. Changes the root path for
-samples.
+Used under the ‹[control](/headers/control)› header.
 
 ## Example
 


### PR DESCRIPTION
- Default path gets reset by a new control header
- Default path can be used as a general prefix for samples, not just a path prefix

The way the control header information is worded in the sfz book makes it seem that all controls opcodes should be reset on a new control header and not just default_path, but sforzando does not implement this behavior and it's not entirely unreasonable.