### PR TITLE
added "bus" opcode to syntax.yml

### DIFF
--- a/_data/sfz/syntax.yml
+++ b/_data/sfz/syntax.yml
@@ -4462,6 +4462,13 @@ categories:
     value:
       type_name: "string"
 
+  - name: "bus"
+    short_description:
+      "Set bus=midi to create midi pre-processing effects"
+    version: "ARIA"
+    value:
+      type_name: "string"
+
   - name: "param_offset"
     short_description:
       "Adds a number to the parameter numbers of built-in

--- a/opcodes/bus.md
+++ b/opcodes/bus.md
@@ -1,0 +1,1 @@
+../headers/midi.md


### PR DESCRIPTION
I cannot find any additional information or usage of this opcode
outside of the areaengine.com forum post. Should make a symlink to the
midi header page or should have its own page?