### PR TITLE
clarify define/include workaround

### DIFF
--- a/opcodes/define.md
+++ b/opcodes/define.md
@@ -35,5 +35,5 @@ easily. Defining the same variable to have multiple values at different points i
 same instrument, however, requires care. Using #define to set the same variable to
 different values at one point in the same SFZ file does not work well at least in
 ARIA/Sforzando when loading an instrument. However, a workaround there is to
-use [#include](/opcodes/include) to put each #define statement in a separate file.
-In simple tests, that has been successful.
+use [#include](/opcodes/include) to put each set of #define statements with different
+values in a separate file.  In simple tests, that has been successful.


### PR DESCRIPTION
Clarify what needs to go in separate files.