### PR TITLE
Fix signed 32 bit integer & example

### DIFF
--- a/_data/sfz/syntax.yml
+++ b/_data/sfz/syntax.yml
@@ -529,8 +529,8 @@ categories:
       value:
         type_name: "integer"
         default: 0
-        min: 0
-        max: 4294967296
+        min: -2147483648
+        max: 2147483647
       alias:
       - name: "offby"
 

--- a/opcodes/off_by.md
+++ b/opcodes/off_by.md
@@ -8,9 +8,16 @@ this region will be turned off.
 ## Examples
 
 ```
-off_by=3
+<region>
+sample=*sine
+key=60
+group= 1
+off_by= 2
 
-off_by=334
+<region>
+sample=*silence
+key=62
+group= 2
 ```
 
 This is used in conjunction with [group](/opcodes/group) to make things


### PR DESCRIPTION
off_by takes in 32 bit signed values. 

Example is from @kinwie

https://github.com/sfztools/sfizz/issues/909