### PR TITLE
Added SFZ to HISE converter to converters section

### DIFF
--- a/_data/sfz/software.yml
+++ b/_data/sfz/software.yml
@@ -464,6 +464,16 @@ categories:
     - name: "Windows"
     short_description:
       ""
+      
+  - name: "SFZ to HISE Converter"
+    author: "Anders Eklöv"
+    license: "MIT"
+    url: "https://keypleezer.com/sfz-to-hise-converter/"
+    os:
+    - name: "Linux"
+    - name: "macOS"
+    - name: "Windows"
+    short_description: "Parses and translates/converts SFZ instruments to HISE samplemaps and extracts SFZ opcode data to a JS/JSON object. Runs in a web browser."
 
 - name: "Misc"
   applications:


### PR DESCRIPTION
New tool that runs in a web browser. Made in JS and reads a SFZ instrument file and spits out a HISE samplemap (for VST instrument creation) and a JSON object literal that can be copied to clipboard with a click. For any OS or device running a modern web browser. 