### PR TITLE
Correct reference to Equator 2 in index.md

### DIFF
--- a/_data/sfz/software.yml
+++ b/_data/sfz/software.yml
@@ -244,16 +244,6 @@ categories:
     short_description:
       "Sampler device supports the import of SFZ. Also via drag & drop."
 
-  - name: "Equator 2"
-    author: "Roli"
-    license: "Commercial"
-    url: "https://roli.com/products/software/equator2/"
-    os:
-    - name: "macOS"
-    - name: "Windows"
-    short_description:
-      "MPE synthesizer."
-
   - name: "HISE"
     author: "Hart Instruments"
     license: "GPL-3.0"

--- a/software/players/index.md
+++ b/software/players/index.md
@@ -16,7 +16,7 @@ as "software to be freely used, modified, and shared."
 ## Supported Opcodes
 
 Below are the known links to the various lists of supported opcodes:\
-[BassMIDI], [Bitwig], [Equator 2], [HISE], [LinuxSampler], [liquidsfz],
+[BassMIDI], [Bitwig], [HISE], [LinuxSampler], [liquidsfz],
 [OpenMPT], [sfizz] and [zerberus] (MuseScore <= v3.6.2).
 
 {% include sfz/software-table-generator.liquid %}
@@ -24,10 +24,10 @@ Below are the known links to the various lists of supported opcodes:\
 
 ## No longer available
 
-- Cakewalk [sfz] (backup on web.archive.org)
 - Alchemy (Camel Audio was acquired by Apple,
   and the current incarnation of Alchemy no longer supports SFZ.)
-
+- Cakewalk [sfz] (backup on web.archive.org)
+- Equator 2 (per [Equator 2 FAQ], "SFZ import is not currently supported")
 
 [ARIA extensions]: {{ '/opcodes/?v=aria' | relative_url }}
 [SFZ v1]:          {{ '/opcodes/?v=1' | relative_url }}
@@ -36,7 +36,7 @@ Below are the known links to the various lists of supported opcodes:\
 [sfz]: https://web.archive.org/web/20071011005744/http://www.rgcaudio.com/sfz.htm
 [BassMIDI]:     https://www.un4seen.com/doc/#bassmidi/BASS_MIDI_FontInit.html
 [Bitwig]:       https://github.com/sfzformat/sfzformat.github.io/pull/48#issuecomment-731244523
-[Equator 2]:    https://github.com/sfzformat/sfzformat.github.io/wiki/Player-Equator2
+[Equator 2 FAQ]: https://support.roli.com/support/solutions/articles/36000255935-equator2-faqs#Can-I-import-my-own-samples-or-wavetable-files-into-Equator2?
 [HISE]:         https://github.com/christophhart/HISE/blob/master/hi_sampler/sampler/SfzImporter.h#L47
 [LinuxSampler]: http://linuxsampler.org/sfz/
 [liquidsfz]:    https://github.com/swesterfeld/liquidsfz/blob/master/OPCODES.md


### PR DESCRIPTION
Roli Equator 2 does not support SFZ import any more. See the Roli FAQ at https://support.roli.com/support/solutions/articles/36000255935-equator2-faqs#Can-I-import-my-own-samples-or-wavetable-files-into-Equator2? and this forum post: https://support.roli.com/support/discussions/topics/36000003275

In index.md, I have fixed the Equator 2 references and alphabetized the entries under "No longer available"
In the data file, I have removed Equator 2

I probably should have done these separately, but I'm not great at Git. They are related, so I hope they can all be merged.