### PR TITLE
Improve legato playability

### DIFF
--- a/docs/tutorials/legato.md
+++ b/docs/tutorials/legato.md
@@ -192,7 +192,7 @@ would be very simple:
 // Legato transitions and the complete sustain of the next note both in the same sample
 trigger=legato
 group=2
-off_by=1
+off_by=2
 ampeg_attack=0.05 ampeg_release=0.2
 off_mode=normal
 
@@ -215,7 +215,7 @@ are short, then fade in the regular sustain sample.
 // Legato transitions in one sample, crossfaded into standard sustain in another sample
 trigger=legato
 group=2
-off_by=1
+off_by=2
 ampeg_attack=0.05 ampeg_release=0.2
 off_mode=normal
 


### PR DESCRIPTION
Changing `off_by` to `2` improves the legato playability considerably. When this setting is at `1`, you can keep the previous note pressed only for the first legato transition. After the second legato transition, monophonic legato is broken because all previous voices won't be stopped by sforzando.

By changing this setting to `2`, any new note in the legato group will automatically stop the previous one which ensures monophonic behavior (which is expected with true legato sample).