### PR TITLE
Fix link to sfizz

### DIFF
--- a/data/sfz/software.yml
+++ b/data/sfz/software.yml
@@ -58,7 +58,7 @@ categories:
   - name: "sfizz"
     author: "SFZTools"
     license: "BSD-2-Clause"
-    url: "https://sfz.tools/sfizz/"
+    url: "https://sfztools.github.io/sfizz/"
     os:
     - name: "Linux"
     - name: "macOS"


### PR DESCRIPTION
The old sfz.tools domain has been squatted (see https://github.com/sfztools/sfizz/issues/1308), so this updates the sfizz URL to point to the new site.