### PR TITLE
Update SFZ Players Table

### DIFF
--- a/data/sfz/software.yml
+++ b/data/sfz/software.yml
@@ -128,6 +128,7 @@ categories:
     license: "Freeware"
     url: "https://plogue.com/products/sforzando.html"
     os:
+    - name: "Linux"
     - name: "macOS"
     - name: "Windows"
     short_description:
@@ -139,6 +140,7 @@ categories:
     license: "Freeware"
     url: "https://www.tx16wx.com/"
     os:
+    - name: "Linux"
     - name: "macOS"
     - name: "Windows"
 


### PR DESCRIPTION
Update SFZ Players Table: `TX16Wx Sampler` and `sforzando` have Linux support now.

* `TX16Wx` download page: https://www.tx16wx.com/download/ (`.deb` and `.rpm` package for linux)
* `sforzando` download page: https://www.plogue.com/downloads.html#sforzando (beta version for linux)