### PR TITLE
Default value fix for sw opcodes.

### DIFF
--- a/data/sfz/syntax.yml
+++ b/data/sfz/syntax.yml
@@ -974,7 +974,7 @@ categories:
       version: "SFZ v1"
       value:
         type_name: "integer"
-        default: 0
+        default: -1
         min: 0
         max: 127
 
@@ -985,7 +985,7 @@ categories:
       version: "SFZ v1"
       value:
         type_name: "integer"
-        default: 127
+        default: -1
         min: 0
         max: 127
 
@@ -997,7 +997,7 @@ categories:
       version: "SFZ v1"
       value:
         type_name: "integer"
-        default: 0
+        default: -1
         min: 0
         max: 127
 
@@ -1010,7 +1010,7 @@ categories:
       version: "SFZ v1"
       value:
         type_name: "integer"
-        default: 0
+        default: -1
         min: 0
         max: 127
 
@@ -1021,7 +1021,7 @@ categories:
       version: "SFZ v1"
       value:
         type_name: "integer"
-        default: 0
+        default: -1
         min: 0
         max: 127
 


### PR DESCRIPTION
Updating default for sw_ opcodes - should be -1 which means no key... probably, but should be confirmed before merging