### PR TITLE
Clarify why silent notes can happen

### DIFF
--- a/docs/opcodes/seq_position.md
+++ b/docs/opcodes/seq_position.md
@@ -7,6 +7,10 @@ The player will keep an internal counter creating a consecutive
 note-on sequence for each region, starting at 1 and resetting at seq_length.
 Maximum allowed value is 100.
 
+Note that, as with other opcodes that restrict when a region plays,
+`seq_position` is _combined_ with other playback restrictions.
+If you have irregular region mappings, you may find you have "silent" steps.
+
 ## Example
 
 ```sfz


### PR DESCRIPTION
Regarding https://discord.com/channels/570240469804777472/1039636242477879367/1507709026757120162

Clarify why irregular mappings of regions using other playback restrictions, when combined with `seq_position` can cause silent regions.