### PR TITLE
Add examples for regions triggered by MIDI CC not MIDI notes

### DIFF
--- a/docs/opcodes/key.md
+++ b/docs/opcodes/key.md
@@ -49,9 +49,9 @@ the lokey value it would set will override the previous lokey.
 lokey=70 key=72
 ```
 
-For cases where a region should not actually be triggered by a key (usually this
-is the case with regions triggered by MIDI CC changes), the special value of key=-1
-can be used.
+For cases where a region should not actually be triggered by a MIDI note message (usually
+this means a region triggered by MIDI CC changes, for example the movement of piano
+pedals), the special value of -1 can be used:
 
 ```sfz
 key=-1

--- a/docs/opcodes/key.md
+++ b/docs/opcodes/key.md
@@ -49,5 +49,13 @@ the lokey value it would set will override the previous lokey.
 lokey=70 key=72
 ```
 
+For cases where a region should not actually be triggered by a key (usually this
+is the case with regions triggered by MIDI CC changes), the special value of key=-1
+can be used.
+
+```sfz
+key=-1
+```
+
 
 [pitch_keycenter]: pitch_keycenter.md

--- a/docs/opcodes/lokey.md
+++ b/docs/opcodes/lokey.md
@@ -37,6 +37,15 @@ When an instrument is sampled every minor third, this kind of usage will be comm
 <region> sample=eb5.wav lokey=74 hikey=76 pitch_keycenter=75
 ```
 
+For cases where a region should not actually be triggered by a MIDI note message (usually
+this means a region triggered by MIDI CC changes, for example the movement of piano pedals),
+the special value of -1 can be used:
+
+```sfz
+lokey=-1
+hikey=-1
+```
+
 
 [key]:                key.md
 [on_loccN / onhiccN]: on_loccN.md

--- a/docs/opcodes/on_loccN.md
+++ b/docs/opcodes/on_loccN.md
@@ -5,18 +5,30 @@ title: "on_loccN / on_hiccN"
 Sample trigger on MIDI continuous control N.
 This does not involve playing any MIDI notes.
 
-## Example
+## Examples
 
 ```sfz
 on_locc64=127 on_hicc64=127
+key=-1
 ```
 
 Region will play when a MIDI CC64 (sustain pedal) message with 127 value is
 received. So, basically, when the sustain pedal is pressed down, this region will play.
 This is useful with piano pedals - in the above example, `on_loccN` and `on_hiccN`
 could be used to trigger a mechanical noise sample, whether any keys are being played
-or not. It would not typically be used with hi-hat pedals, as most electronic drum kits
-will send a MIDI note when the pedal hits bottom.
+or not (which is what the [key]=-1 part is for). It would not typically be used with
+hi-hat pedals, as most electronic drum kits will send a MIDI note when the pedal hits bottom.
+
+```sfz
+on_locc64=127 on_hicc64=127
+key=-1
+end=-1
+sample=*silence
+```
+
+This is similar to the first example, but triggers a silent region which is terminated
+immediately. This would be used where there is no mechanical noise to trigger, but a region
+still needs to be triggered in order to mute other regions.
 
 ## Practical Considerations
 
@@ -30,3 +42,4 @@ like a normal release or release_key region.
 
 
 [trigger]: trigger.md
+[key]: key.md


### PR DESCRIPTION
Add end=-1 and key=-1 to the onccN example, as that's how things actuallly work, and also mention -1 in the lokey/hikey/key descriptions.